### PR TITLE
Update Evernote note on save using an EventListener...

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,6 +1,3 @@
 [
-  { "keys": ["ctrl+alt+e"], "command": "send_to_evernote" },
-  { "keys": ["ctrl+s"], "command": "save_evernote_note",
-    "context": [{ "key": "setting.$evernote", "operator": "equal", "operand": true }]
-  }
+  { "keys": ["ctrl+alt+e"], "command": "send_to_evernote" }
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,6 +1,3 @@
 [
-  { "keys": ["super+alt+e"], "command": "send_to_evernote" },
-  { "keys": ["super+s"], "command": "save_evernote_note",
-    "context": [{ "key": "setting.$evernote", "operator": "equal", "operand": true }]
-  }
+  { "keys": ["super+alt+e"], "command": "send_to_evernote" }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -1,6 +1,3 @@
 [
-  { "keys": ["ctrl+alt+e"], "command": "send_to_evernote" },
-  { "keys": ["ctrl+s"], "command": "save_evernote_note",
-    "context": [{ "key": "setting.$evernote", "operator": "equal", "operand": true }]
-  }
+  { "keys": ["ctrl+alt+e"], "command": "send_to_evernote" }
 ]

--- a/sublime_evernote.py
+++ b/sublime_evernote.py
@@ -360,6 +360,12 @@ class SaveEvernoteNoteCommand(EvernoteDoText):
         return False
 
 
+class SaveEvernoteNote(sublime_plugin.EventListener):
+
+    def on_post_save(self, view):
+        view.run_command("save_evernote_note")
+
+
 class OpenEvernoteNoteCommand(EvernoteDoWindow):
 
     def do_run(self):


### PR DESCRIPTION
...instead of binding command to the default save key.

Tried out this fork today and I really like it! I noticed that when I save, though, the evernote note is updated (which is great) but my local copy is not saved (and I would like it to be).

This adds an `EventListener` that triggers a call to `save_evernote_note` `on_post_save`.

The only downside I can see is that the status message about the evernote update is overwritten immediately with the status message about saving.
